### PR TITLE
Implement license expiry trigger

### DIFF
--- a/.github/workflows/ansible-playbook-configure-zabbix-server.yml
+++ b/.github/workflows/ansible-playbook-configure-zabbix-server.yml
@@ -20,6 +20,7 @@
           - "apt-transport-https" # required for HTTPS repository urls
           - "python-setuptools" # required for pip
           - "python3-pip" # required to install python modules (see next task)
+          - "shellcheck" # required for checking the syntax of shell scripts
         state: latest
 
     - name: install required python modules for ansible

--- a/.github/workflows/ansible-playbook-import-template.yml
+++ b/.github/workflows/ansible-playbook-import-template.yml
@@ -19,6 +19,7 @@
         mode: '0755'
       with_fileglob:
         - "../../zabbix_agentd.d/*.conf"
+        - "../../zabbix_agentd.d/*.sh"
     
     - name: restart zabbix-agent
       systemd:

--- a/.github/workflows/github-ci-main.yml
+++ b/.github/workflows/github-ci-main.yml
@@ -54,3 +54,6 @@ jobs:
         with:
           inventory: localhost
           playbook: .github/workflows/ansible-playbook-import-template.yml
+
+      - name: check shell script sytnax
+        run: shellcheck zabbix_agentd.d/*.sh

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ This template also gathers some information using the active Zabbix agent. There
     ```shell
     cd /etc/zabbix/zabbix_agentd.d/
     wget https://raw.githubusercontent.com/TS3Tools/zabbix-teamspeak-template/main/zabbix_agentd.d/userparameter_teamspeak.conf
+    wget https://raw.githubusercontent.com/TS3Tools/zabbix-teamspeak-template/main/zabbix_agentd.d/teamspeak_get_converted_license_end_date.sh
     ```
 4. Ensure, that the permissions of these scripts are set correctly
     ```shell
     chown root:root -R /etc/zabbix/zabbix_agentd.d/
-    chmod 644 /etc/zabbix/zabbix_agentd.d/*
+    chmod 644 /etc/zabbix/zabbix_agentd.d/*.conf
+    chmod 755 /etc/zabbix/zabbix_agentd.d/*.sh
     ```
 5. Restart the Zabbix agent to load the configuration of these new user parameters
     ```shell

--- a/templates/Template_App_TeamSpeak_3.xml
+++ b/templates/Template_App_TeamSpeak_3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>5.0</version>
-    <date>2021-04-30T16:00:47Z</date>
+    <date>2021-05-28T15:35:56Z</date>
     <groups>
         <group>
             <name>Templates/Applications</name>
@@ -61,6 +61,12 @@
                             <name>TS3 Instance Build version changed ({ITEM.LASTVALUE} =&gt; {ITEM.VALUE})</name>
                             <priority>INFO</priority>
                             <description>The build version of the TeamSpeak instance changed. This usually happens sometimes after an upgrade of the TeamSpeak instance.</description>
+                        </trigger>
+                        <trigger>
+                            <expression>{change()}=1</expression>
+                            <name>TS3 Instance license expiry date changed ({ITEM.PREV} =&gt; {ITEM.LASTVALUE})</name>
+                            <priority>INFO</priority>
+                            <description>The expiry date of the TeamSpeak instance license changed. This usually happens automatically regulary, when the license is still active and in use.</description>
                         </trigger>
                     </triggers>
                 </item>
@@ -543,14 +549,45 @@
                     <type>ZABBIX_ACTIVE</type>
                     <key>teamspeak.license_end_date[{$TS3_INSTANCE_HOME_DIR}]</key>
                     <delay>1h</delay>
-                    <trends>0</trends>
-                    <value_type>CHAR</value_type>
+                    <units>unixtime</units>
                     <description>The date and time, when the license of the TeamSpeak instance approx. expires.</description>
                     <applications>
                         <application>
                             <name>TeamSpeak 3 Server</name>
                         </application>
                     </applications>
+                    <triggers>
+                        <trigger>
+                            <expression>{last()}-{now()}&lt;=0</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}-{now()}&gt;0</recovery_expression>
+                            <name>TS3 Instance license expired</name>
+                            <priority>DISASTER</priority>
+                            <description>The license of the TeamSpeak instance expired. Your TeamSpeak instance is now limited to the default amount of maximum virtual servers and slots.&#13;
+&#13;
+TeamSpeak usually automatically renews the license 30 days prior to the expiration date, when it's still activley in use and the license fee is paid. Depending on the license you might also need to replace your license with a newer one.</description>
+                        </trigger>
+                        <trigger>
+                            <expression>{last()}-{now()}&lt;1209600</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}-{now()}&gt;1209600 or {last()}-{now()}&lt;=0</recovery_expression>
+                            <name>TS3 Instance license expires soon (&lt;14 days)</name>
+                            <priority>HIGH</priority>
+                            <description>The license of the TeamSpeak instance expires in less than 14 days.&#13;
+&#13;
+TeamSpeak usually automatically renews the license 30 days prior to the expiration date, when it's still activley in use and the license fee is paid. Depending on the license you might also need to replace your license with a newer one.</description>
+                        </trigger>
+                        <trigger>
+                            <expression>{last()}-{now()}&lt;2160000</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}-{now()}&gt;2160000 or {last()}-{now()}&lt;1209600</recovery_expression>
+                            <name>TS3 Instance license expires soon (&lt;25 days)</name>
+                            <priority>WARNING</priority>
+                            <description>The license of the TeamSpeak instance expires in less than 25 days.&#13;
+&#13;
+TeamSpeak usually automatically renews the license 30 days prior to the expiration date, when it's still activley in use and the license fee is paid. Depending on the license you might also need to replace your license with a newer one.</description>
+                        </trigger>
+                    </triggers>
                 </item>
                 <item>
                     <name>TS3 License Max. Slots</name>

--- a/zabbix_agentd.d/get_converted_license_end_date.sh
+++ b/zabbix_agentd.d/get_converted_license_end_date.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# About: Gets the TeamSpeak license expiry date and converts it to a Unix timestamp.
+# Author: Sebastian Krätzig <sebastian.kraetzig@ts3-tools.info>
+# Source: https://github.com/TS3Tools/zabbix-teamspeak-template
+
+TEAMSPEAK_ROOT_DIR=${1}
+
+IFS=' ' read -r -a LICENSE_END_DATE_ARRAY <<< $(grep -Ei '^end date' ${TEAMSPEAK_ROOT_DIR}/licensekey.dat | cut -d ':' -f 2- | xargs)
+
+date -d "${LICENSE_END_DATE_ARRAY[2]} ${LICENSE_END_DATE_ARRAY[1]} ${LICENSE_END_DATE_ARRAY[4]} ${LICENSE_END_DATE_ARRAY[3]}" +"%s" -u | xargs

--- a/zabbix_agentd.d/userparameter_teamspeak.conf
+++ b/zabbix_agentd.d/userparameter_teamspeak.conf
@@ -1,6 +1,6 @@
 UserParameter=teamspeak.license_type[*], grep -Ei "^type" $1/licensekey.dat | cut -d ":" -f 2- | xargs
 UserParameter=teamspeak.license_max_virtual_servers[*], grep -Ei "^max. virtual servers" $1/licensekey.dat | cut -d ":" -f 2- | xargs
 UserParameter=teamspeak.license_max_slots[*], grep -Ei "^max. slots" $1/licensekey.dat | cut -d ":" -f 2- | xargs
-UserParameter=teamspeak.license_end_date[*], grep -Ei "^end date" $1/licensekey.dat | cut -d ":" -f 2- | xargs
+UserParameter=teamspeak.license_end_date[*], /etc/zabbix/zabbix_agentd.d/teamspeak_get_converted_license_end_date.sh $1
 UserParameter=teamspeak.process_id[*], cat $1/ts3server.pid
 UserParameter=teamspeak.process_id_active[*], sudo kill -0 $(cat $1/ts3server.pid) 2> /dev/null && echo 1 || echo 0


### PR DESCRIPTION
- License expiry date is now saved as unsigned number instead of a character
- License expiry date contains now a Unix timestamp instead of a human readable string
- Adds trigger for checking the license expiry date

Additionally, this merge request also adds some shell script syntax checking to the pipeline.